### PR TITLE
fix: API Gateway 스테이지를 $default로 변경

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -75,7 +75,7 @@ Resources:
   TarotHttpApi:
     Type: AWS::Serverless::HttpApi
     Properties:
-      StageName: prod
+      StageName: $default
       CorsConfiguration:
         AllowOrigins:
           - "https://aitarot.site"
@@ -92,7 +92,7 @@ Resources:
 Outputs:
   TarotApiUrl:
     Description: API Gateway endpoint URL
-    Value: !Sub "https://${TarotHttpApi}.execute-api.${AWS::Region}.amazonaws.com/prod"
+    Value: !Sub "https://${TarotHttpApi}.execute-api.${AWS::Region}.amazonaws.com"
   TarotFunction:
     Description: Lambda Function ARN
     Value: !GetAtt TarotFunction.Arn


### PR DESCRIPTION
URL에서 /prod 경로 제거하여 커스텀 도메인 연결 시 깔끔한 경로 사용 가능.