### PR TITLE
fix: 타로 카드 데이터를 SSM Parameter Store에서 로드

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -14,6 +14,7 @@ Globals:
         GEMINI_API_KEY_PARAM: !Ref GeminiApiKeyParam
         FIREBASE_CREDENTIALS_PARAM: !Ref FirebaseCredentialsParam
         TAROT_SYSTEM_PROMPT_PARAM: !Ref TarotSystemPromptParam
+        TAROT_CARDS_PARAM: !Ref TarotCardsParam
 
 Parameters:
   GeminiApiKeyParam:
@@ -28,6 +29,10 @@ Parameters:
     Type: String
     Description: SSM Parameter Store path for Tarot system prompt
     Default: "/arcana-whisper/prompts/tarot-system"
+  TarotCardsParam:
+    Type: String
+    Description: SSM Parameter Store path for Tarot cards data
+    Default: "/arcana-whisper/tarot-cards"
   AllowedOrigins:
     Type: String
     Default: "https://aitarot.site,https://www.aitarot.site"

--- a/src/utils/json_loader.py
+++ b/src/utils/json_loader.py
@@ -1,5 +1,46 @@
 import json
+import logging
+import os
 
-def get_tarot_cards(path) -> list[dict]:
-    with open(path, "r", encoding="utf-8") as file:
-        return json.load(file)
+logger = logging.getLogger(__name__)
+
+_CACHED_TAROT_CARDS = None
+
+
+def _get_from_ssm(param_name: str) -> str:
+    """AWS Systems Manager Parameter Store에서 값 로드"""
+    import boto3
+    ssm = boto3.client("ssm")
+    response = ssm.get_parameter(Name=param_name, WithDecryption=True)
+    return response["Parameter"]["Value"]
+
+
+def get_tarot_cards(file_path: str = None) -> list[dict]:
+    """타로 카드 데이터를 SSM 또는 파일에서 로드합니다."""
+    global _CACHED_TAROT_CARDS
+
+    if _CACHED_TAROT_CARDS is not None:
+        return _CACHED_TAROT_CARDS
+
+    # 1. SSM Parameter Store에서 로드 (Lambda 환경)
+    param_name = os.environ.get("TAROT_CARDS_PARAM")
+    if param_name:
+        try:
+            cards_json = _get_from_ssm(param_name)
+            _CACHED_TAROT_CARDS = json.loads(cards_json)
+            logger.info(f"Loaded tarot cards from SSM: {param_name}")
+            return _CACHED_TAROT_CARDS
+        except Exception as e:
+            logger.warning(f"Failed to load tarot cards from SSM: {e}, trying file...")
+
+    # 2. 파일에서 로드 (로컬 테스트용)
+    if file_path:
+        try:
+            with open(file_path, "r", encoding="utf-8") as file:
+                _CACHED_TAROT_CARDS = json.load(file)
+                logger.info(f"Loaded tarot cards from file: {file_path}")
+                return _CACHED_TAROT_CARDS
+        except FileNotFoundError:
+            pass
+
+    raise RuntimeError("Tarot cards not found. Set TAROT_CARDS_PARAM or provide valid file path.")


### PR DESCRIPTION
Lambda 환경에서 tarot_cards.json 파일 접근 문제 해결
- json_loader.py에 SSM 로드 로직 추가 (캐싱 포함)
- template.yaml에 TAROT_CARDS_PARAM 환경변수 추가