### PR TITLE
chore: 백엔드 배포 워크플로우를 OIDC로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ env:
   AWS_REGION: ap-northeast-2
   STACK_NAME: arcana-whisper
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,9 +33,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::339712740233:role/github-actions-arcanawhisper-deploy
 
       - name: Build SAM application
         run: |


### PR DESCRIPTION
## 변경 내용
- GitHub Actions 워크플로우에 `id-token: write`, `contents: read` 권한 추가
- `aws-actions/configure-aws-credentials`를 Access Key 방식에서 `role-to-assume` 기반 OIDC 방식으로 변경
- 백엔드 배포가 `github-actions-arcanawhisper-deploy` 역할을 사용하도록 수정

## 확인 포인트
- GitHub Actions 실행 시 `Configure AWS credentials` 단계가 정상 통과하는지
- 기존 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` 없이 배포가 정상 동작하는지