### PR TITLE
chore: 백엔드 CORS 도메인을 tarotnow.cloud로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.aitarot.site">Service</a> •  
+  <a href="https://tarotnow.cloud">Service</a> •  
   <a href="https://github.com/gguip1/ArcanaWhisper-Front">Frontend Repo</a>
 </p>
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -35,7 +35,7 @@ Parameters:
     Default: "/arcana-whisper/tarot-cards"
   AllowedOrigins:
     Type: String
-    Default: "https://aitarot.site,https://www.aitarot.site"
+    Default: "https://tarotnow.cloud"
     Description: Allowed CORS origins (comma separated)
 
 Resources:
@@ -124,9 +124,7 @@ Resources:
     Properties:
       StageName: $default
       CorsConfiguration:
-        AllowOrigins:
-          - "https://aitarot.site"
-          - "https://www.aitarot.site"
+        AllowOrigins: !Split [",", !Ref AllowedOrigins]
         AllowHeaders:
           - Content-Type
           - Authorization


### PR DESCRIPTION
## 변경 내용
- API Gateway HTTP API의 허용 origin 기본값을 `https://tarotnow.cloud`로 변경
- CORS 설정이 `AllowedOrigins` 파라미터를 직접 사용하도록 정리
- README 서비스 링크를 새 도메인으로 갱신

## 확인 포인트
- `sam deploy` 후 API Gateway CORS 설정에 `https://tarotnow.cloud`가 반영되는지
- 프론트에서 API 호출 시 브라우저 CORS 오류가 발생하지 않는지