### PR TITLE
ci: 백엔드 배포 워크플로우 액션 버전과 SAM 설치 방식을 갱신

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,18 +20,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Setup AWS SAM CLI
         uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+          token: ${{ github.token }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::339712740233:role/github-actions-arcanawhisper-deploy


### PR DESCRIPTION
## 요약
백엔드 배포 워크플로우의 GitHub Actions 버전을 올리고, SAM CLI 설치를 네이티브 installer 방식으로 전환했습니다.

## 변경 배경
GitHub Actions의 Node.js 20 지원 중단 경고가 발생하고 있었고, SAM CLI 설치 단계도 더 빠른 installer 경로를 쓰는 편이 적절했습니다.

## 변경 내용
checkout, setup-python, configure-aws-credentials 액션 버전을 최신 메이저로 올렸습니다.
setup-sam은 v2를 유지하되 use-installer와 github.token을 추가해 네이티브 설치 경로를 사용하도록 바꿨습니다.

## 영향 범위
백엔드 배포 워크플로우 파일만 변경됩니다.
애플리케이션 코드나 SAM 템플릿 리소스 변경은 없습니다.

## 테스트
워크플로우 파일 정적 검토만 진행했습니다.
실제 동작 확인은 PR 머지 후 다음 배포 실행에서 확인할 예정입니다.