### PR TITLE
chore: API Gateway CORS origin을 템플릿 고정값으로 변경

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -33,10 +33,6 @@ Parameters:
     Type: String
     Description: SSM Parameter Store path for Tarot cards data
     Default: "/arcana-whisper/tarot-cards"
-  AllowedOrigins:
-    Type: String
-    Default: "https://tarotnow.cloud"
-    Description: Allowed CORS origins (comma separated)
 
 Resources:
   # Lambda Function
@@ -124,7 +120,8 @@ Resources:
     Properties:
       StageName: $default
       CorsConfiguration:
-        AllowOrigins: !Split [",", !Ref AllowedOrigins]
+        AllowOrigins:
+          - https://tarotnow.cloud
         AllowHeaders:
           - Content-Type
           - Authorization


### PR DESCRIPTION
## 요약
API Gateway HTTP API의 CORS origin을 CloudFormation 파라미터가 아니라 템플릿 고정값으로 바꿨습니다.

## 변경 배경
기존 스택은 AllowedOrigins 파라미터 값을 계속 재사용하고 있어서, 템플릿의 기본값만 바꿔도 운영 CORS 값이 갱신되지 않았습니다.

## 변경 내용
AllowedOrigins 파라미터를 제거했습니다.
HTTP API CorsConfiguration.AllowOrigins에 https://tarotnow.cloud 를 직접 명시했습니다.

## 영향 범위
백엔드 SAM 템플릿의 CORS 설정만 변경됩니다.
Lambda 코드나 API 라우트 로직 변경은 없습니다.

## 테스트