### PR TITLE
🔧 chore: ChatGoogleGenerativeAI 모델 버전을 gemini-2.5-flash-lite로 업데이트

### DIFF
--- a/src/services/tarot_service.py
+++ b/src/services/tarot_service.py
@@ -94,7 +94,7 @@ def detect_injection_attempt(text: str) -> bool:
     return False
 
 LLM = ChatGoogleGenerativeAI(
-            model="gemini-2.0-flash-lite",
+            model="gemini-2.5-flash-lite",
             temperature=0.5,
             api_key=get_api_key('GEMINI_API_KEY'),
         )


### PR DESCRIPTION
## 변경 사항

* `gemini-2.0-flash-lite` → `gemini-2.5-flash-lite` 변경
* 기존 API 호출 로직은 유지하고 모델명만 교체

## 변경 이유

* 기존 모델 Deprecated로 인한 API 호출 오류 해결

## 추후 개선

* 모델명을 코드에 하드코딩하지 않고 환경변수 또는 설정값으로 분리해, 모델 변경 시 코드 수정 없이 대응 가능하도록 개선 예정